### PR TITLE
Fix CityGML ADE

### DIFF
--- a/CitySim.cbp
+++ b/CitySim.cbp
@@ -14,7 +14,7 @@
 				<Option deps_output="C:/Documents and Settings/cgiller/Bureau/SVN/Dtool/.deps" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters='&quot;C:\Users\kaempf\SWITCHdrive\Simulations\Marta\CROCETTA(o.p.).xml&quot;' />
+				<Option parameters='&quot;C:\src\CitySim\Solver\bin\Hassan\0- House-basecase-adaptation.xml&quot;' />
 				<Option projectResourceIncludeDirsRelation="1" />
 				<Compiler>
 					<Add option="-Wfatal-errors" />
@@ -36,10 +36,9 @@
 				<Option deps_output="C:/Documents and Settings/cgiller/Bureau/SVN/Dtool/.deps" />
 				<Option type="1" />
 				<Option compiler="gcc" />
-				<Option parameters='&quot;C:\Users\kaempf\Desktop\CityGML\nord.xml&quot;' />
+				<Option parameters='&quot;C:\src\CitySim\Solver\bin\Hassan\0- House-basecase-adaptation.xml&quot;' />
 				<Option projectResourceIncludeDirsRelation="1" />
 				<Compiler>
-					<Add option="-march=core2" />
 					<Add option="-O2" />
 					<Add option="-fopenmp" />
 				</Compiler>

--- a/Makefile.mingw32
+++ b/Makefile.mingw32
@@ -1,46 +1,67 @@
 CXX		= g++
-CXXFLAGS	= -fopenmp -march=native -O2 -DTIXML_USE_STL
-LD		= g++
-LDFLAGS		= -fopenmp
-LIBRARIES	= -lglu32
-INCLUDES	= -I./NR -I./Sky -I./Tinyxml -I./VFCLibrary
+F95		= gfortran
+CXXFLAGS	= -std=c++11 -O2 -fopenmp -fPIC -DTIXML_USE_STL
+LDFLAGS		= -lGLU32 -lgfortran -lquadmath -fopenmp
+CXXFLAGS_D	= -std=c++11 -g -DDEBUG -DTIXML_USE_STL
+LDFLAGS_D	= -lGLU32 -lgfortran -lquadmath
+INCLUDES	= -I./Sky -I./Tinyxml -I./VFCLibrary
 DEFINES		=
+AR		= ar
 EXEC		= CitySim
-LIB			= lib$(EXEC).dll
+EXEC_D		= CitySimd
+LIB		= lib$(EXEC).dll
 
-MAINSRC		= building.cpp district.cpp models.cpp plant.cpp scene.cpp zone.cpp climate.cpp occupants.cpp result.cpp util.cpp
-NRSRC		= $(wildcard ./NR/*.cpp)
+MAINSRC		= building.cpp district.cpp models.cpp plant.cpp scene.cpp zone.cpp climate.cpp occupants.cpp result.cpp util.cpp surface.cpp
+LAPACKSRC	= $(wildcard ./LAPACK/*.f)
 SKYSRC		= $(wildcard ./Sky/*.cpp)
 TINYXMLSRC	= $(wildcard ./Tinyxml/*.cpp)
 VFCLIBRARYSRC	= $(wildcard ./VFCLibrary/*.cpp)
+
 MAINOBJ		= $(patsubst %.cpp, %.o, $(MAINSRC))
-NROBJ		= $(patsubst %.cpp, %.o, $(NRSRC))
+LAPACKOBJ	= $(patsubst %.f, %.o, $(LAPACKSRC))
 SKYOBJ		= $(patsubst %.cpp, %.o, $(SKYSRC))
 TINYXMLOBJ	= $(patsubst %.cpp, %.o, $(TINYXMLSRC))
 VFCLIBRARYOBJ	= $(patsubst %.cpp, %.o, $(VFCLIBRARYSRC))
 
-all: $(EXEC) $(LIB)
+MAINOBJ_D	= $(patsubst %.cpp, %d.o, $(MAINSRC))
+LAPACKOBJ_D	= $(patsubst %.f, %d.o, $(LAPACKSRC))
+SKYOBJ_D	= $(patsubst %.cpp, %d.o, $(SKYSRC))
+TINYXMLOBJ_D	= $(patsubst %.cpp, %d.o, $(TINYXMLSRC))
+VFCLIBRARYOBJ_D	= $(patsubst %.cpp, %d.o, $(VFCLIBRARYSRC))
 
-$(EXEC): main.o $(MAINOBJ) $(NROBJ) $(SKYOBJ) $(TINYXMLOBJ) $(VFCLIBRARYOBJ)
-	$(LD) -static $(LDFLAGS) -o $@ $^ $(LIBRARIES)
+all: $(EXEC) $(EXEC_D) $(LIB)
 
-$(LIB): $(MAINOBJ) $(NROBJ) $(SKYOBJ) $(TINYXMLOBJ) $(VFCLIBRARYOBJ)
-	$(CXX) -shared $(LDFLAGS) -o $@ $^ $(LIBRARIES)
+$(EXEC): main.o $(MAINOBJ) $(LAPACKOBJ) $(SKYOBJ) $(TINYXMLOBJ) $(VFCLIBRARYOBJ)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+	move $(EXEC).exe ./bin
 
-fromLib: $(LIB)
-	$(CXX) $(INCLUDES) $(LDFLAGS) -Wl,--enable-auto-import -o $(EXEC) main.cpp -L. -lCitySim $(LIBRARIES)
+$(EXEC_D): maind.o $(MAINOBJ_D) $(LAPACKOBJ_D) $(SKYOBJ_D) $(TINYXMLOBJ_D) $(VFCLIBRARYOBJ_D)
+	$(CXX) -o $@ $^ $(LDFLAGS_D)
+	move $(EXEC_D).exe ./bin
+
+$(LIB): $(MAINOBJ) $(LAPACKOBJ) $(SKYOBJ) $(TINYXMLOBJ) $(VFCLIBRARYOBJ)
+	$(AR) rcs $@ $^
+	move $(LIB) ./lib/CitySim 
+	xcopy .\\*.h .\\lib\\CitySim /y
+	xcopy .\\Sky\\*.h .\\lib\\CitySim /y
+	xcopy .\\Tinyxml\\*.h .\\lib\\CitySim /y
+	xcopy .\\VFCLibrary\\*.h .\\lib\\CitySim /y
+	xcopy .\\VFCLibrary\\*.inl .\\lib\\CitySim /y
+	xcopy main.cpp .\\lib\\CitySim /y
+	@echo all: main.cpp $(LIB) > ./lib/CitySim/Makefile
+	@echo 	$(CXX) $(CXXFLAGS) -L. main.cpp -l$(EXEC) $(LDFLAGS) -o $(EXEC) >> ./lib/CitySim/Makefile
 
 %.o: %.cpp
 	$(CXX) $(INCLUDES) $(DEFINES) $(CXXFLAGS) -c $< -o $*.o
 
-clean:
-	erase *.o
+%.o: %.f
+	$(F95) -c -O2 $< -o $*.o
 
-	erase .\NR\*.o
+%d.o: %.cpp
+	$(CXX) $(INCLUDES) $(DEFINES) $(CXXFLAGS_D) -c $< -o $*d.o
 
-	erase .\Sky\*.o
+%d.o: %.f
+	$(F95) -c -g $< -o $*d.o
 
-	erase .\Tinyxml\*.o
-
-	erase .\VFCLibrary\*.o
-
+clean: 
+	del /f /s *.o

--- a/building.cpp
+++ b/building.cpp
@@ -1179,13 +1179,61 @@ void Building::writeXML(ofstream& file, string tab){
 
 void Building::writeGML(ofstream& file, string tab) {
 
-    file << tab << "<bldg:Building gml:id=\"";
+    // output of the PV panel
+    for (size_t i=0; i < zones.size(); ++i) {
+        // writes the different surface elements
+        for (size_t j=0; j < zones[i]->getnWalls(); ++j) {
+            if (zones[i]->getWall(j)->getPVRatio() > 0.f) {
+                file << tab << "<core:cityObjectMember>\n"
+                     << tab << "\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
+                     << tab << "\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getWall(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
+                     << tab << "\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getWall(j)->getPVRatio()*zones[i]->getWall(j)->getArea() << "</energy:collectorSurface>\n"
+                     << tab << "\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
+                     << tab << "\t\t\t<gen:value uom=\"deg\">" << zones[i]->getWall(j)->getAzimuth() << "</gen:value>\n"
+                     << tab << "\t\t</gen:measureAttribute>\n"
+                     << tab << "\t\t<gen:measureAttribute name=\"panelInclination\">\n"
+                     << tab << "\t\t\t<gen:value uom=\"deg\">\n" << zones[i]->getWall(j)->getAltitude() << "</gen:value>\n"
+                     << tab << "\t\t</gen:measureAttribute>\n"
+                     << tab << "\t\t<energy:installedOnBoundarySurface xlink:href=\"#";
+                    if (zones[i]->getWall(j)->getKey().empty())
+                        file << "Wall_" << zones[i]->getWall(j)->getId() << "\">" << endl;
+                    else
+                        file << zones[i]->getWall(j)->getKey() << "\">" << endl;
+                file << tab << "\t</energy:PhotovoltaicSystem>\n"
+                     << tab << "</core:cityObjectMember>\n" << flush;
+            }
+        }
+        for (size_t j=0; j < zones[i]->getnRoofs(); ++j) {
+            if (zones[i]->getRoof(j)->getPVRatio() > 0.f) {
+                file << tab << "<core:cityObjectMember>\n"
+                     << tab << "\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
+                     << tab << "\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getRoof(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
+                     << tab << "\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getRoof(j)->getPVRatio()*zones[i]->getRoof(j)->getArea() << "</energy:collectorSurface>\n"
+                     << tab << "\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
+                     << tab << "\t\t\t<gen:value uom=\"deg\">" << zones[i]->getRoof(j)->getAzimuth() << "</gen:value>\n"
+                     << tab << "\t\t</gen:measureAttribute>\n"
+                     << tab << "\t\t<gen:measureAttribute name=\"panelInclination\">\n"
+                     << tab << "\t\t\t<gen:value uom=\"deg\">" << zones[i]->getRoof(j)->getAltitude() << "</gen:value>\n"
+                     << tab << "\t\t</gen:measureAttribute>\n"
+                     << tab << "\t\t<energy:installedOnBoundarySurface xlink:href=\"#";
+                    if (zones[i]->getRoof(j)->getKey().empty())
+                        file << "Roof_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
+                    else
+                        file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
+                file << tab << "\t</energy:PhotovoltaicSystem>\n"
+                     << tab << "</core:cityObjectMember>\n" << flush;
+            }
+        }
+    }
+
+    file << tab << "<core:cityObjectMember>" << endl;
+    file << tab << "\t<bldg:Building gml:id=\"";
     if (key.empty())
         file << "Bldg-" << id << "\">" << endl;
     else
         file << key << "\">" << endl;
 
-    string subtab=tab+"\t";
+    string subtab=tab+"\t\t";
 
     // add the energy demand computed by CitySim
     if (pDistrict->getScene()->getTimeStepsSimulated() > 0) {
@@ -1326,22 +1374,6 @@ void Building::writeGML(ofstream& file, string tab) {
 //                 << subtab << "\t\t\t</energy:RegularTimeSeriesFile>\n"
 //                 << subtab << "\t\t</energy:globalSolarIrradiance>\n"
                  << flush;
-            // output of the PV panel
-            if (zones[i]->getWall(j)->getPVRatio() > 0.f) {
-                file << subtab << "\t\t<energy:equippedWith>\n"
-                     << subtab << "\t\t\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
-                     << subtab << "\t\t\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getWall(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
-                     << subtab << "\t\t\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getWall(j)->getPVRatio()*zones[i]->getWall(j)->getArea() << "</energy:collectorSurface>\n"
-                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
-                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\"> \n" << zones[i]->getWall(j)->getAzimuth() << "</gen:value>\n"
-                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
-                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelInclination\">\n"
-                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\">\n" << zones[i]->getWall(j)->getAltitude() << "</gen:value>\n"
-                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
-                     << subtab << "\t\t\t\t<energy:installedOnBoundarySurface xlink:href=\"#Wall_" << zones[i]->getWall(j)->getId() << "\"/>\n"
-                     << subtab << "\t\t\t</energy:PhotovoltaicSystem>\n"
-                     << subtab << "\t\t</energy:equippedWith>\n" << flush;
-            }
             file << subtab << "\t</bldg:WallSurface>\n"
                  << subtab << "</bldg:boundedBy>" << endl;
         }
@@ -1373,22 +1405,6 @@ void Building::writeGML(ofstream& file, string tab) {
 //                 << subtab << "\t\t\t</energy:RegularTimeSeriesFile>\n"
 //                 << subtab << "\t\t</energy:globalSolarIrradiance>\n"
                  << flush;
-            // output of the PV panel
-            if (zones[i]->getRoof(j)->getPVRatio() > 0.f) {
-                file << subtab << "\t\t<energy:equippedWith>\n"
-                     << subtab << "\t\t\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
-                     << subtab << "\t\t\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getRoof(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
-                     << subtab << "\t\t\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getRoof(j)->getPVRatio()*zones[i]->getRoof(j)->getArea() << "</energy:collectorSurface>\n"
-                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
-                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\"> \n" << zones[i]->getRoof(j)->getAzimuth() << "</gen:value>\n"
-                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
-                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelInclination\">\n"
-                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\">\n" << zones[i]->getRoof(j)->getAltitude() << "</gen:value>\n"
-                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
-                     << subtab << "\t\t\t\t<energy:installedOnBoundarySurface xlink:href=\"#Roof_" << zones[i]->getRoof(j)->getId() << "\"/>\n"
-                     << subtab << "\t\t\t</energy:PhotovoltaicSystem>\n"
-                     << subtab << "\t\t</energy:equippedWith>\n" << flush;
-            }
             file << subtab << "\t</bldg:RoofSurface>\n"
                  << subtab << "</bldg:boundedBy>" << endl;
         }
@@ -1607,7 +1623,8 @@ void Building::writeGML(ofstream& file, string tab) {
     file << subtab << "</energy:usageZone>" << endl;
 
     // close the tag building
-    file << tab << "</bldg:Building>" << endl;
+    file << subtab << "\t</bldg:Building>" << endl;
+    file << tab << "</core:cityObjectMember>" << endl;
 }
 
 void Building::computeVolume() {

--- a/building.cpp
+++ b/building.cpp
@@ -906,6 +906,14 @@ Building::Building(TiXmlHandle hdl, District* pDistrict):pDistrict(pDistrict),lo
             }
             else zones.back()->setTmax(to<float>(hdl.ToElement()->Attribute("Tmax")));
 
+            // adds the night ventilation
+            if (hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("nightVentilationBegin")) {
+                zones.back()->setNightVentilationBegin(to<unsigned int>(hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("nightVentilationBegin")));
+            }
+            if (hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("nightVentilationEnd")) {
+                zones.back()->setNightVentilationEnd(to<unsigned int>(hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("nightVentilationEnd")));
+            }
+
             // adds the ep_id if it exists
             if (hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("ep_id")) {
                     zones.back()->setEp_id(hdl.ChildElement("Zone",zoneIndex).ToElement()->Attribute("ep_id"));

--- a/building.cpp
+++ b/building.cpp
@@ -1521,7 +1521,7 @@ void Building::writeGML(ofstream& file, string tab) {
         file << subtab << tabs(6) << "<energy:totalValue uom=\"W\">" << zones.at(i)->getOccupantsNumber()*(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:totalValue>" << endl;
         file << subtab << tabs(5) << "</energy:HeatExchangeType>" << endl;
         file << subtab << tabs(4) << "</energy:heatDissipation>" << endl;
-        file << subtab << tabs(4) << "<energy:numberOfOccupants>" << zones.at(i)->getOccupantsNumber() << "</energy:numberOfOccupants>" << endl;
+        file << subtab << tabs(4) << "<energy:numberOfOccupants>" << round(zones.at(i)->getOccupantsNumber()) << "</energy:numberOfOccupants>" << endl;
         /* -> compute occupancyRate according to stochastic and deterministic profiles ? */
         file << subtab << tabs(4) << "<energy:occupancyRate>" << endl;
         file << subtab << tabs(5) << "<energy:TimeSeriesSchedule>" << endl;

--- a/building.cpp
+++ b/building.cpp
@@ -1200,6 +1200,7 @@ void Building::writeGML(ofstream& file, string tab) {
                     else
                         file << zones[i]->getWall(j)->getKey() << "\">" << endl;
                 file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
+                     << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
                      << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }
@@ -1222,6 +1223,7 @@ void Building::writeGML(ofstream& file, string tab) {
                     else
                         file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
                 file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
+                     << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
                      << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }

--- a/building.cpp
+++ b/building.cpp
@@ -1261,42 +1261,30 @@ void Building::writeGML(ofstream& file, string tab) {
          << tab << "\t\t\t<gml:exterior>\n"
          << tab << "\t\t\t\t<gml:CompositeSurface>\n";
 
-    subtab=tab+"\t\t\t\t\t";
+    subtab=tab+"\t";
 
     for (size_t i=0; i < zones.size(); ++i) {
         // writes the different surface elements
         for (size_t j=0; j < zones[i]->getnWalls(); ++j) {
-            file << subtab << "<gml:surfaceMember>\n"
-                 << subtab << "\t<gml:Polygon ";
+            file << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
             if (zones[i]->getWall(j)->getKey().empty())
-                file << "gml:id=\"b" << id << "_p_w_" << zones[i]->getWall(j)->getId() << "\">" << endl;
+                file << "b" << id << "_p_w_" << zones[i]->getWall(j)->getId() << "\">" << endl;
             else
-                file << "gml:id=\"" << zones[i]->getWall(j)->getKey() << "\">" << endl;
-            zones[i]->getWall(j)->writeGML(file,subtab+"\t");
-            file << subtab << "\t</gml:Polygon>\n"
-                 << subtab << "</gml:surfaceMember>" << endl;
+                file << zones[i]->getWall(j)->getKey() << "\">" << endl;
         }
         for (size_t j=0; j < zones[i]->getnRoofs(); ++j) {
-            file << subtab << "<gml:surfaceMember>\n"
-                 << subtab << "\t<gml:Polygon ";
+            file << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
             if (zones[i]->getRoof(j)->getKey().empty())
-                file << "gml:id=\"b" << id << "_p_r_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
+                file << "b" << id << "_p_r_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
             else
-                file << "gml:id=\"" << zones[i]->getRoof(j)->getKey() << "\">" << endl;
-            zones[i]->getRoof(j)->writeGML(file,subtab+"\t");
-            file << subtab << "\t</gml:Polygon>\n"
-                 << subtab << "</gml:surfaceMember>" << endl;
+                file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
         }
         for (size_t j=0; j < zones[i]->getnFloors(); ++j) {
-            file << subtab << "<gml:surfaceMember>\n"
-                 << subtab << "\t<gml:Polygon ";
+            file << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
             if (zones[i]->getFloor(j)->getKey().empty())
-                file << "gml:id=\"b" << id << "_p_g_" << zones[i]->getFloor(j)->getId() << "\">" << endl;
+                file << "b" << id << "_p_g_" << zones[i]->getFloor(j)->getId() << "\">" << endl;
             else
-                file << "gml:id=\"" << zones[i]->getFloor(j)->getKey() << "\">" << endl;
-            zones[i]->getFloor(j)->writeGML(file,subtab+"\t");
-            file << subtab << "\t</gml:Polygon>\n"
-                 << subtab << "</gml:surfaceMember>" << endl;
+                file << zones[i]->getFloor(j)->getKey() << "\">" << endl;
         }
     }
 
@@ -1305,7 +1293,7 @@ void Building::writeGML(ofstream& file, string tab) {
          << tab << "\t\t</gml:Solid>\n"
          << tab << "\t</bldg:lod2Solid>" << endl;
 
-    // add the bounded by tags, in order to recognize Wall, Roof and Floor using xlink:href and the id
+    // add the bounded by tags, in order to recognize Wall, Roof and Floor
     subtab=tab+"\t";
     for (size_t i=0; i < zones.size(); ++i) {
         // writes the different surface elements
@@ -1314,12 +1302,15 @@ void Building::writeGML(ofstream& file, string tab) {
                  << subtab << "\t<bldg:WallSurface gml:id=\"Wall_" << zones[i]->getWall(j)->getId() << "\">\n"
                  << subtab << "\t\t<bldg:lod2MultiSurface>\n"
                  << subtab << "\t\t\t<gml:MultiSurface>\n"
-                 << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
-            if (zones[i]->getWall(j)->getKey().empty())
-                file << "b" << id << "_p_w_" << zones[i]->getWall(j)->getId() << "\">" << endl;
-            else
-                file << zones[i]->getWall(j)->getKey() << "\">" << endl;
-            file << subtab << "\t\t\t\t</gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t<gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t\t<gml:Polygon ";
+                if (zones[i]->getWall(j)->getKey().empty())
+                    file << "gml:id=\"b" << id << "_p_w_" << zones[i]->getWall(j)->getId() << "\">" << endl;
+                else
+                    file << "gml:id=\"" << zones[i]->getWall(j)->getKey() << "\">" << endl;
+                zones[i]->getWall(j)->writeGML(file,subtab+"\t");
+                file << subtab << "\t\t\t\t\t</gml:Polygon>\n"
+                 << subtab << "\t\t\t\t</gml:surfaceMember>\n"
                  << subtab << "\t\t\t</gml:MultiSurface>\n"
                  << subtab << "\t\t</bldg:lod2MultiSurface>\n"
 // removed in version 1.0 (to be checked)
@@ -1355,12 +1346,15 @@ void Building::writeGML(ofstream& file, string tab) {
                  << subtab << "\t<bldg:RoofSurface gml:id=\"Roof_" << zones[i]->getRoof(j)->getId() << "\">\n"
                  << subtab << "\t\t<bldg:lod2MultiSurface>\n"
                  << subtab << "\t\t\t<gml:MultiSurface>\n"
-                 << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
-            if (zones[i]->getRoof(j)->getKey().empty())
-                file << "b" << id << "_p_r_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
-            else
-                file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
-            file << subtab << "\t\t\t\t</gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t<gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t\t<gml:Polygon ";
+                if (zones[i]->getRoof(j)->getKey().empty())
+                    file << "gml:id=\"b" << id << "_p_r_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
+                else
+                    file << "gml:id=\"" << zones[i]->getRoof(j)->getKey() << "\">" << endl;
+                zones[i]->getRoof(j)->writeGML(file,subtab+"\t");
+                file << subtab << "\t\t\t\t\t</gml:Polygon>\n"
+                 << subtab << "\t\t\t\t</gml:surfaceMember>\n"
                  << subtab << "\t\t\t</gml:MultiSurface>\n"
                  << subtab << "\t\t</bldg:lod2MultiSurface>\n"
 //                 << subtab << "\t\t<energy:globalSolarIrradiance>\n"
@@ -1395,12 +1389,15 @@ void Building::writeGML(ofstream& file, string tab) {
                  << subtab << "\t<bldg:GroundSurface gml:id=\"Floor_" << zones[i]->getFloor(j)->getId() << "\">\n"
                  << subtab << "\t\t<bldg:lod2MultiSurface>\n"
                  << subtab << "\t\t\t<gml:MultiSurface>\n"
-                 << subtab << "\t\t\t\t<gml:surfaceMember xlink:href=\"#";
-            if (zones[i]->getFloor(j)->getKey().empty())
-                file << "b" << id << "_p_g_" << zones[i]->getFloor(j)->getId() << "\">" << endl;
-            else
-                file << zones[i]->getFloor(j)->getKey() << "\">" << endl;
-            file << subtab << "\t\t\t\t</gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t<gml:surfaceMember>\n"
+                 << subtab << "\t\t\t\t\t<gml:Polygon ";
+                if (zones[i]->getFloor(j)->getKey().empty())
+                    file << "gml:id=\"b" << id << "_p_g_" << zones[i]->getFloor(j)->getId() << "\">" << endl;
+                else
+                    file << "gml:id=\"" << zones[i]->getFloor(j)->getKey() << "\">" << endl;
+                zones[i]->getFloor(j)->writeGML(file,subtab+"\t");
+                file << subtab << "\t\t\t\t\t</gml:Polygon>\n"
+                 << subtab << "\t\t\t\t</gml:surfaceMember>\n"
                  << subtab << "\t\t\t</gml:MultiSurface>\n"
                  << subtab << "\t\t</bldg:lod2MultiSurface>\n"
                  << subtab << "\t</bldg:GroundSurface>\n"

--- a/building.cpp
+++ b/building.cpp
@@ -1482,7 +1482,7 @@ void Building::writeGML(ofstream& file, string tab) {
     // add the occupancy through the UsageZone
     file << subtab << "<energy:usageZone>" << endl;
     for (size_t i=0; i < zones.size(); ++i) {
-        file << subtab << tabs(1) << "<energy:UsageZone gml:id=\"ID_" << zones.at(i)->getId() << "\">" << endl;
+        file << subtab << tabs(1) << "<energy:UsageZone gml:id=\"UZ_" << zones.at(i)->getId() << "\">" << endl;
         // cooling schedule
         file << subtab << tabs(2) << "<energy:coolingSchedule>" << endl;
         file << subtab << tabs(3) << "<energy:ConstantValueSchedule>" << endl;

--- a/building.cpp
+++ b/building.cpp
@@ -1199,7 +1199,8 @@ void Building::writeGML(ofstream& file, string tab) {
                         file << "Wall_" << zones[i]->getWall(j)->getId() << "\">" << endl;
                     else
                         file << zones[i]->getWall(j)->getKey() << "\">" << endl;
-                file << tab << "\t</energy:PhotovoltaicSystem>\n"
+                file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
+                     << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }
         }
@@ -1220,7 +1221,8 @@ void Building::writeGML(ofstream& file, string tab) {
                         file << "Roof_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
                     else
                         file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
-                file << tab << "\t</energy:PhotovoltaicSystem>\n"
+                file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
+                     << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }
         }

--- a/building.cpp
+++ b/building.cpp
@@ -1332,9 +1332,13 @@ void Building::writeGML(ofstream& file, string tab) {
                      << subtab << "\t\t\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
                      << subtab << "\t\t\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getWall(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
                      << subtab << "\t\t\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getWall(j)->getPVRatio()*zones[i]->getWall(j)->getArea() << "</energy:collectorSurface>\n"
-                     << subtab << "\t\t\t\t<energy:panelAzimuth uom=\"deg\">" << zones[i]->getWall(j)->getAzimuth() << "</energy:panelAzimuth>\n"
-                     << subtab << "\t\t\t\t<energy:panelInclination uom=\"deg\">" << zones[i]->getWall(j)->getAltitude() << "</energy:panelInclination>\n"
-                     << subtab << "\t\t\t\t<energy:installedOn xlink:href=\"#Wall_" << zones[i]->getWall(j)->getId() << "\"/>\n"
+                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
+                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\"> \n" << zones[i]->getWall(j)->getAzimuth() << "</gen:value>\n"
+                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
+                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelInclination\">\n"
+                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\">\n" << zones[i]->getWall(j)->getAltitude() << "</gen:value>\n"
+                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
+                     << subtab << "\t\t\t\t<energy:installedOnBoundarySurface xlink:href=\"#Wall_" << zones[i]->getWall(j)->getId() << "\"/>\n"
                      << subtab << "\t\t\t</energy:PhotovoltaicSystem>\n"
                      << subtab << "\t\t</energy:equippedWith>\n" << flush;
             }
@@ -1375,9 +1379,13 @@ void Building::writeGML(ofstream& file, string tab) {
                      << subtab << "\t\t\t<energy:PhotovoltaicSystem gml:id=\"PV_1\">\n"
                      << subtab << "\t\t\t\t<energy:nominalEfficiency uom=\"ratio\">" << zones[i]->getRoof(j)->getPVPanel()->getMaxPowerEfficiency(800.,20.) << "</energy:nominalEfficiency>\n"
                      << subtab << "\t\t\t\t<energy:collectorSurface uom=\"m2\">" << zones[i]->getRoof(j)->getPVRatio()*zones[i]->getRoof(j)->getArea() << "</energy:collectorSurface>\n"
-                     << subtab << "\t\t\t\t<energy:panelAzimuth uom=\"deg\">" << zones[i]->getRoof(j)->getAzimuth() << "</energy:panelAzimuth>\n"
-                     << subtab << "\t\t\t\t<energy:panelInclination uom=\"deg\">" << zones[i]->getRoof(j)->getAltitude() << "</energy:panelInclination>\n"
-                     << subtab << "\t\t\t\t<energy:installedOn xlink:href=\"#Roof_" << zones[i]->getRoof(j)->getId() << "\"/>\n"
+                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelAzimuth\">\n"
+                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\"> \n" << zones[i]->getRoof(j)->getAzimuth() << "</gen:value>\n"
+                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
+                     << subtab << "\t\t\t\t<gen:measureAttribute name=\"panelInclination\">\n"
+                     << subtab << "\t\t\t\t\t<gen:value uom=\"deg\">\n" << zones[i]->getRoof(j)->getAltitude() << "</gen:value>\n"
+                     << subtab << "\t\t\t\t</gen:measureAttribute>\n"
+                     << subtab << "\t\t\t\t<energy:installedOnBoundarySurface xlink:href=\"#Roof_" << zones[i]->getRoof(j)->getId() << "\"/>\n"
                      << subtab << "\t\t\t</energy:PhotovoltaicSystem>\n"
                      << subtab << "\t\t</energy:equippedWith>\n" << flush;
             }

--- a/building.cpp
+++ b/building.cpp
@@ -1432,7 +1432,7 @@ void Building::writeGML(ofstream& file, string tab) {
             zones[i]->getWall(j)->writeGML_composedOf(file,subtab+"\t\t\t\t");
 
             // the partOf is made if you have one surface that belongs to two different zones (e.g. ZoneSurface)
-            file << subtab << "\t\t\t\t<energy:delimits xlink:href=\"TZ_" << zones.at(i)->getId() << "\"/>" << endl;
+            file << subtab << "\t\t\t\t<energy:delimits xlink:href=\"#TZ_" << zones.at(i)->getId() << "\"/>" << endl;
 
             // this is where the link is given to the boundedBy Surface
             file << subtab << tabs(4) << "<energy:relatesTo xlink:href=\"#Wall_" << zones[i]->getWall(j)->getId() << "\"/>" << endl;

--- a/building.cpp
+++ b/building.cpp
@@ -1515,9 +1515,9 @@ void Building::writeGML(ofstream& file, string tab) {
         file << subtab << tabs(3) << "<energy:Occupants>" << endl;
         file << subtab << tabs(4) << "<energy:heatDissipation>" << endl;
         file << subtab << tabs(5) << "<energy:HeatExchangeType>" << endl;
-        file << subtab << tabs(6) << "<energy:convectiveFraction uom=\"none\">" << zones.at(i)->getOccupantsSensibleHeat()*(1.f-zones.at(i)->getOccupantsSensibleHeatRadiantFraction())/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:convectiveFraction>" << endl;
-        file << subtab << tabs(6) << "<energy:latentFraction uom=\"none\">" << zones.at(i)->getOccupantsLatentHeat()/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:latentFraction>" << endl;
-        file << subtab << tabs(6) << "<energy:radiantFraction uom=\"none\">" << zones.at(i)->getOccupantsSensibleHeat()*zones.at(i)->getOccupantsSensibleHeatRadiantFraction()/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:radiantFraction>" << endl;
+        file << subtab << tabs(6) << "<energy:convectiveFraction uom=\"ratio\">" << zones.at(i)->getOccupantsSensibleHeat()*(1.f-zones.at(i)->getOccupantsSensibleHeatRadiantFraction())/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:convectiveFraction>" << endl;
+        file << subtab << tabs(6) << "<energy:latentFraction uom=\"ratio\">" << zones.at(i)->getOccupantsLatentHeat()/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:latentFraction>" << endl;
+        file << subtab << tabs(6) << "<energy:radiantFraction uom=\"ratio\">" << zones.at(i)->getOccupantsSensibleHeat()*zones.at(i)->getOccupantsSensibleHeatRadiantFraction()/(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:radiantFraction>" << endl;
         file << subtab << tabs(6) << "<energy:totalValue uom=\"W\">" << zones.at(i)->getOccupantsNumber()*(zones.at(i)->getOccupantsSensibleHeat()+zones.at(i)->getOccupantsLatentHeat()) << "</energy:totalValue>" << endl;
         file << subtab << tabs(5) << "</energy:HeatExchangeType>" << endl;
         file << subtab << tabs(4) << "</energy:heatDissipation>" << endl;

--- a/building.cpp
+++ b/building.cpp
@@ -1199,8 +1199,11 @@ void Building::writeGML(ofstream& file, string tab) {
                         file << "Wall_" << zones[i]->getWall(j)->getId() << "\">" << endl;
                     else
                         file << zones[i]->getWall(j)->getKey() << "\">" << endl;
-                file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
-                     << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
+                    if (key.empty())
+                        file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>"  << endl;
+                    else
+                        file << tab << "\t\t<energy:installedIn xlink:href=\"#" << key << "\"/>"  << endl;
+                file << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
                      << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }
@@ -1222,8 +1225,11 @@ void Building::writeGML(ofstream& file, string tab) {
                         file << "Roof_" << zones[i]->getRoof(j)->getId() << "\">" << endl;
                     else
                         file << zones[i]->getRoof(j)->getKey() << "\">" << endl;
-                file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>\n"
-                     << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
+                    if (key.empty())
+                        file << tab << "\t\t<energy:installedIn xlink:href=\"#Bldg-" << id << "\"/>"  << endl;
+                    else
+                        file << tab << "\t\t<energy:installedIn xlink:href=\"#" << key << "\"/>"  << endl;
+                file << tab << "\t\t<energy:cellType>monocrystalline</energy:cellType>\n"
                      << tab << "\t</energy:PhotovoltaicSystem>\n"
                      << tab << "</core:cityObjectMember>\n" << flush;
             }

--- a/district.cpp
+++ b/district.cpp
@@ -429,16 +429,17 @@ void District::writeXML(ofstream& file, string tab){
 
 void District::writeGML(ofstream& file, string tab) {
 
+    // write the composites
+    for (map<string,Composite*>::iterator it=composites.begin();it!=composites.end();++it) {
+        file << tab << "<gml:featureMember>" << endl;
+        it->second->writeGML(file, tab+"\t");
+        file << tab << "</gml:featureMember>" << endl;
+    }
+
     // write the buildings
     for (size_t i=0; i<buildings.size(); ++i) {
         file << tab << "<core:cityObjectMember>" << endl;
         buildings[i]->writeGML(file, tab+"\t");
-        file << tab << "</core:cityObjectMember>" << endl;
-    }
-    // write the composites
-    for (map<string,Composite*>::iterator it=composites.begin();it!=composites.end();++it) {
-        file << tab << "<core:cityObjectMember>" << endl;
-        it->second->writeGML(file, tab+"\t");
         file << tab << "</core:cityObjectMember>" << endl;
     }
 }

--- a/district.cpp
+++ b/district.cpp
@@ -438,9 +438,9 @@ void District::writeGML(ofstream& file, string tab) {
 
     // write the buildings
     for (size_t i=0; i<buildings.size(); ++i) {
-        file << tab << "<core:cityObjectMember>" << endl;
-        buildings[i]->writeGML(file, tab+"\t");
-        file << tab << "</core:cityObjectMember>" << endl;
+
+        buildings[i]->writeGML(file, tab);
+
     }
 }
 

--- a/occupants.cpp
+++ b/occupants.cpp
@@ -8,7 +8,7 @@
 // *** Occupants class, CitySim  *** //
 // *** jerome.kaempf@epfl.ch     *** //
 
-DayProfile OccupancyProfiles::emptyDay(0,"empty day profile",vector<float>(365,0));
+DayProfile OccupancyProfiles::emptyDay(0,"empty day profile",vector<float>(24,0));
 YearProfile OccupancyProfiles::emptyYear = YearProfile(0,"empty year profile",vector<DayProfile*>(365,&OccupancyProfiles::emptyDay));
 
 StochasticOccupantsPresence::StochasticOccupantsPresence(float occupantsNumber, StochasticPresenceParameters *presParam, StochasticWindowParameters *winParam, StochasticBlindsParameters *blindsParam, StochasticLightsParameters *lightsParam) : Occupants(occupantsNumber)

--- a/plant.cpp
+++ b/plant.cpp
@@ -3596,11 +3596,6 @@ void DistrictEnergyCenter::deleteDynAllocated() {
     if (pipelineNetwork!=nullptr) { delete pipelineNetwork; }
 }
 
-DistrictEnergyCenter::~DistrictEnergyCenter() {
-    logStream << "Destructor of DistrictEnergyCenter" << endl;
-    deleteDynAllocated();
-}
-
 double DistrictEnergyCenter::getMu(double temp) {
     float mu_ = 0.0004; // JK - added default value to 0.0004
     if (mu==muPossibilities[0]){ mu_ = 0.0004; }
@@ -3753,13 +3748,6 @@ Network::Network(TiXmlHandle hdl, DistrictEnergyCenter *pDEC, ostream *pLogStr) 
         // should it throw error ?
     }
 }
-
-
-Network::~Network() {
-    logStream << "Destructor of Network" << endl;
-    deleteNodesAndPipes();
-}
-
 
 void Network::writeTHHeaderText(fstream& textFile) {
     unsigned int decId = pDEC->getId();

--- a/plant.h
+++ b/plant.h
@@ -845,7 +845,7 @@ protected:
 public:
     static Substation* createNewSubstation(TiXmlHandle hdl,  Building* pBui, unsigned int beginD, unsigned int endD, ostream* pLogStr = &std::cout);
     Substation(TiXmlHandle hdl,  Building* pBui, unsigned int beginD, unsigned int endD, ostream* pLogStr = &std::cout);
-    virtual ~Substation() { delete valve; logStream << "Destructor of Substation" << endl; }
+    virtual ~Substation() { delete valve; /*logStream << "Destructor of Substation" << endl;*/ }
 
     void writeXML(ofstream& file, string tab){ file << tab << "Substation saving not supported yet" << endl; }
     string getLabel() { return "Substation"; }
@@ -991,7 +991,7 @@ private:
     HeatPump* heatPump;
 public:
     SubstationHeatPump(TiXmlHandle hdl, Building* pBui, unsigned int beginD, unsigned int endD, ostream* pLogStr = &std::cout);
-    virtual ~SubstationHeatPump() { logStream << "Destructor of SubstationHP" << endl; }
+    virtual ~SubstationHeatPump() { /*logStream << "Destructor of SubstationHP" << endl;*/ }
     void writeXML(ofstream& file, string tab) override{ file << tab << "SubstationHeatPump saving not supported yet" << endl; }
     string getLabel() override{ return "SubstationHeatPump"; }
     virtual double getThermalPower(double sourceTemp) override;
@@ -1260,7 +1260,7 @@ public:
     static ThermalStation* createNewThermalStation(TiXmlHandle hdl, Network* net, ostream* pLogStr);
 
     ThermalStation(TiXmlHandle hdl, Network* net, ostream* pLogStr);
-    virtual ~ThermalStation() { ThermalStation::deleteDynAllocated(); }
+    virtual ~ThermalStation() { deleteDynAllocated(); }
 
     EnergyConversionSystem* getEcs() { return ecs; }
     float getThermalPowerProvided() { return thermalPowerProvided; }
@@ -1303,7 +1303,6 @@ public:
 class ThermalStationMaster: public ThermalStation{ // One thermal station to rule them all.
 public:
     ThermalStationMaster(TiXmlHandle hdl, Network* net, ostream* pLogStr):ThermalStation(hdl,net,pLogStr){}
-    virtual ~ThermalStationMaster() { ThermalStationMaster::deleteDynAllocated(); }
     bool getMaster(){return true;}
 };
 
@@ -1325,7 +1324,6 @@ private:
 
 public:
     ThermalStationSlave(TiXmlHandle hdl, Network* net, ostream* pLogStr);
-    virtual ~ThermalStationSlave() { ThermalStationSlave::deleteDynAllocated(); }
     void computePressureDiff(float const& massFlow, float const& rho, float& deltaP, float& dDeltaP_dm);
     void setDesiredMassFlow(float rho, float cp, double sourceTemp, Climate* pClimate, unsigned int day, unsigned int hour);
     void updateControlVariable(float const& massFlow, float const& deltaP, float const& rho, float& sumDeltaRpm, float& sumRpm, float& sumDeltaKv, float& sumKv, float const& learningRate);
@@ -1356,27 +1354,27 @@ private:
 
 public:
     SeasonalStorageHeatingThermalStation(TiXmlHandle hdl, Network* net, ostream* pLogStr);
-    virtual ~SeasonalStorageHeatingThermalStation() { SeasonalStorageHeatingThermalStation::deleteDynAllocated(); }
+    ~SeasonalStorageHeatingThermalStation() { deleteDynAllocated(); }
 
-    virtual void computePressureDiff(float const& massFlow, float const& rho, float& deltaP, float& dDeltaP_dm) override;
+    void computePressureDiff(float const& massFlow, float const& rho, float& deltaP, float& dDeltaP_dm) override;
 
-    virtual void updateControlVariable(float const& massFlow, float const& deltaP, float const& rho, float& sumDeltaRpm, float& sumRpm, float& sumDeltaKv, float& sumKv, float const& learningRate) override;
+    void updateControlVariable(float const& massFlow, float const& deltaP, float const& rho, float& sumDeltaRpm, float& sumRpm, float& sumDeltaKv, float& sumKv, float const& learningRate) override;
 
-    virtual void computeThermal(float pressureDiff, float massFlow, float rho, float cp, float inputTemp, Climate *pClimate, unsigned int day, unsigned int hour);
+    void computeThermal(float pressureDiff, float massFlow, float rho, float cp, float inputTemp, Climate *pClimate, unsigned int day, unsigned int hour);
 
-    virtual void updateOperationMode(float const& sumSubstationDesiredMassFlow, size_t const& nbThermalStations) override;
+    void updateOperationMode(float const& sumSubstationDesiredMassFlow, size_t const& nbThermalStations) override;
 
     void confirmStorage(float const& massFlow, float const& cp) { storage->confirmStoredHeat(tempDiffAroundStorage, abs(massFlow), cp); }
 
-    virtual void errorPressureDiff(float const& massFlow, float const& pressureDiff, float& relErr, float& absErr, float& sumErrP, float& sumDesiredP) override;
+    void errorPressureDiff(float const& massFlow, float const& pressureDiff, float& relErr, float& absErr, float& sumErrP, float& sumDesiredP) override;
 
-    virtual void writeTHHeaderText(fstream& textFile, string prefix) override;
-    virtual void writeTHResultsText(fstream& textFile, unsigned int i) override;
+    void writeTHHeaderText(fstream& textFile, string prefix) override;
+    void writeTHResultsText(fstream& textFile, unsigned int i) override;
 
 
-    virtual void recordTimeStep(Climate* pClim, unsigned int day, unsigned int hour, float const& massFlow, float const& cp) override { ThermalStation::recordTimeStep(pClim, day, hour, massFlow, cp);  confirmStorage(massFlow, cp); storage->recordTimeStep(); }
-    virtual void eraseRecords(unsigned int keepValue) override { ThermalStation::eraseRecords(keepValue); storage->eraseRecords(keepValue); }
-    virtual void eraseRecords_back() override { ThermalStation::eraseRecords_back(); storage->eraseRecords_back(); }
+    void recordTimeStep(Climate* pClim, unsigned int day, unsigned int hour, float const& massFlow, float const& cp) override { ThermalStation::recordTimeStep(pClim, day, hour, massFlow, cp);  confirmStorage(massFlow, cp); storage->recordTimeStep(); }
+    void eraseRecords(unsigned int keepValue) override { ThermalStation::eraseRecords(keepValue); storage->eraseRecords(keepValue); }
+    void eraseRecords_back() override { ThermalStation::eraseRecords_back(); storage->eraseRecords_back(); }
 };
 
 
@@ -1809,8 +1807,7 @@ public:
     ostream logStream;
 
     Network(TiXmlHandle hdl, DistrictEnergyCenter *pDEC, ostream *pLogStr);
-
-    ~Network();
+    ~Network() { /*logStream << "Destructor of Network" << endl;*/ deleteNodesAndPipes(); }
 
     float getSoilkValue() { return soilkValue; }
 
@@ -1914,7 +1911,7 @@ public:
     ostream logStream;
 
     DistrictEnergyCenter(TiXmlHandle hdl, District* pDistrict, ostream *pLogStr);
-    ~DistrictEnergyCenter();
+    ~DistrictEnergyCenter() { /*logStream << "Destructor of DistrictEnergyCenter" << endl;*/ deleteDynAllocated(); }
     void deleteDynAllocated();
 
     District* getDistrict() {return pDistrict;}

--- a/surface.h
+++ b/surface.h
@@ -369,7 +369,7 @@ public:
         file << tab << "\t\t\t\t\t<energy:OpticalProperties>" << endl;
         file << tab << "\t\t\t\t\t\t<energy:transmittance>" << endl;
         file << tab << "\t\t\t\t\t\t\t<energy:Transmittance>" << endl;
-        file << tab << "\t\t\t\t\t\t\t\t<energy:fraction uom=\"scale\">" << glazingGvalue << "</energy:fraction>" << endl;
+        file << tab << "\t\t\t\t\t\t\t\t<energy:fraction uom=\"ratio\">" << glazingGvalue << "</energy:fraction>" << endl;
         file << tab << "\t\t\t\t\t\t\t\t<energy:wavelengthRange>total</energy:wavelengthRange>" << endl;
         file << tab << "\t\t\t\t\t\t\t</energy:Transmittance>" << endl;
         file << tab << "\t\t\t\t\t\t</energy:transmittance>" << endl;

--- a/surface.h
+++ b/surface.h
@@ -335,19 +335,19 @@ public:
     }
 
     void writeGML(ofstream& file, string tab=""){
-        file << tab << "\t<gml:exterior>\n"
-             << tab << "\t\t<gml:LinearRing>\n"
-             << tab << "\t\t\t<gml:posList>\n";
-        string subtab = tab + "\t\t\t\t";
+        file << tab << "\t\t\t\t\t<gml:exterior>\n"
+             << tab << "\t\t\t\t\t\t<gml:LinearRing>\n"
+             << tab << "\t\t\t\t\t\t\t<gml:posList>\n";
+        string subtab = tab + "\t\t\t\t\t\t\t\t";
         for (unsigned int i=0; i< vertices.size(); ++i){
             file << subtab << (vertices[i])[0] << " " << (vertices[i])[1] << " " << (vertices[i])[2] << "\n";
         }
         // repeat the first point
         file << subtab << (vertices[0])[0] << " " << (vertices[0])[1] << " " << (vertices[0])[2] << "\n";
         // close the tabs
-        file << tab << "\t\t\t</gml:posList>\n"
-             << tab << "\t\t</gml:LinearRing>\n"
-             << tab << "\t</gml:exterior>" << endl;
+        file << tab << "\t\t\t\t\t\t\t</gml:posList>\n"
+             << tab << "\t\t\t\t\t\t</gml:LinearRing>\n"
+             << tab << "\t\t\t\t\t</gml:exterior>" << endl;
     }
 
     virtual void writeGML_composedOf(ofstream& file, string tab="") {

--- a/zone.cpp
+++ b/zone.cpp
@@ -260,7 +260,8 @@ void Zone::writeXML(ofstream& file, string tab=""){
         file << "true";
     else
         file << "false";
-    file << "\" >" << endl;
+    file << "\" nightVentilationBegin=\"" << nightVentilationBegin << "\" nightVentilationEnd=\"" << nightVentilationEnd;
+    file << "\">" << endl;
     string subtab =tab+"\t";
     file << subtab << "<Occupants n=\"" << occupantsNumber << "\" sensibleHeat=\"" << getOccupantsSensibleHeat()
                                                            << "\" sensibleHeatRadiantFraction=\"" << getOccupantsSensibleHeatRadiantFraction()

--- a/zone.h
+++ b/zone.h
@@ -42,6 +42,8 @@ private:
     // for the stochastic model
     vector<float> lumint;
 
+    unsigned int nightVentilationBegin = 0, nightVentilationEnd = 0; //!< Night ventilation timings during the day
+
 //  vector<double> windowAirExchangeRate;
 //
 //  vector<int> vPresence;
@@ -249,6 +251,11 @@ public:
     float getVdotVent(unsigned int step) { if (VdotVent.empty()) return 0.f; else return VdotVent.at(step); }
     void eraseVdotVent(unsigned int keepValue) { VdotVent.erase(VdotVent.begin(),VdotVent.end()-min(keepValue,(unsigned int)VdotVent.size())); }
     void eraseVdotVent_back() { VdotVent.pop_back(); }
+
+    unsigned int getNightVentilationBegin() { return nightVentilationBegin; }
+    void setNightVentilationBegin(unsigned int value) { nightVentilationBegin = value; }
+    unsigned int getNightVentilationEnd() { return nightVentilationEnd; }
+    void setNightVentilationEnd(unsigned int value) { nightVentilationEnd = value; }
 
     float getRadiativeInternalHeatGains() { return Lr; }
     float getConvectiveInternalHeatGains() { return Lc; }


### PR DESCRIPTION
# Todo

- [ ] `Surface.h L362` Glazing properties should become part of the construction library
- [ ] Usage zone should become an attribute of the Thermal Zone?
Giorgio used this: `<energy:contains xlink:href="#UZ_0"/>` but I am not sure about the relation
- [ ] Drop null attributes (currently set to 0) in construction library
- [ ] Set a unique ID for PV Systems

